### PR TITLE
Allow APIs to use the configured API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ This will create this file: `config/initializers/best_buy.rb`
 
 ## Usage
 
-The gem can be used to access Best Buy [APIs](general-overview.md):
+The gem can be used to access Best Buy [APIs](general_overview.md):
 
-- [Products](products-api.md)
-- [Stores](stores-api.md)
-- [Categories](categories-api.md)
+- [Products](products_api.md)
+- [Stores](stores_api.md)
+- [Categories](categories_api.md)
 
 Example:
 

--- a/docs/categories_api.md
+++ b/docs/categories_api.md
@@ -22,4 +22,4 @@ Attributes:
 
 ## Interface
 
-(For more methods, check the [common API interface](general_overview.md#common-methods))
+(For more methods, check the [common API interface](general_overview.md#common-interface))

--- a/docs/general_overview.md
+++ b/docs/general_overview.md
@@ -8,6 +8,33 @@ The different APIs accessible by this gem are:
 
 In spite of having each their own specification, they all share some basics listed here.
 
+## API key usage
+
+All APIs can be initialized by passing the api key in the `new` method
+
+```ruby
+BestBuy::Products.new(your_api_key)
+```
+But for Ruby on Rails projects, there's an alternative. If you run:
+
+    $ rails generate best_buy:config
+    
+This file will be created: `config/initializers/best_buy.rb`
+
+In that file, you can set up the gem with your API key, so that you don't have to pass it to the different APIs each time. You just have to do it like this:
+
+```ruby
+BestBuy.configure do |config|
+  config.api_key = 'your_api_key'
+end
+```
+
+Then, the next time you instantiate any API you can omit the key:
+
+```ruby
+BestBuy::Products.new
+```
+
 ## Common interface
 
 This method can be used with any of the APIs:

--- a/docs/general_overview.md
+++ b/docs/general_overview.md
@@ -10,31 +10,29 @@ In spite of having each their own specification, they all share some basics list
 
 ## API key usage
 
-All APIs can be initialized by passing the api key in the `new` method
+All APIs can be initialized by passing the API key in the `new` method
 
 ```ruby
 BestBuy::Products.new(your_api_key)
 ```
-But for Ruby on Rails projects, there's an alternative. If you run:
-
-    $ rails generate best_buy:config
-    
-This file will be created: `config/initializers/best_buy.rb`
-
-In that file, you can set up the gem with your API key, so that you don't have to pass it to the different APIs each time. You just have to do it like this:
-
+But the key can also be set up in a `configure` method available for the `BestBuy` module:
 ```ruby
 BestBuy.configure do |config|
   config.api_key = 'your_api_key'
 end
 ```
-
 Then, the next time you instantiate any API you can omit the key:
 
 ```ruby
 BestBuy::Products.new
 ```
+For Ruby on Rails projects you can run:
 
+    $ rails generate best_buy:config
+    
+To generate this file: `config/initializers/best_buy.rb`, where you can write the configuration code.
+
+For non Ruby on Rails projects, you can still write the configuration code wherever you like, as long as you make sure it runs before trying to access the APIs.
 ## Common interface
 
 This method can be used with any of the APIs:

--- a/docs/products_api.md
+++ b/docs/products_api.md
@@ -56,7 +56,7 @@ Attributes:
 
 ## Interface
 
-(For more methods, check the [common API interface](general_overview.md#common-methods))
+(For more methods, check the [common API interface](general_overview.md#common-interface))
 
 #### `get_by(conditions)`
 

--- a/docs/stores_api.md
+++ b/docs/stores_api.md
@@ -49,7 +49,7 @@ store.address # returns '50 Holyoke St'
 
 ## Interface
 
-(For more methods, check the [common API interface](general_overview.md#common-methods))
+(For more methods, check the [common API interface](general_overview.md#common-interface))
 
 #### `find(store_id)`
 

--- a/lib/best_buy.rb
+++ b/lib/best_buy.rb
@@ -34,4 +34,4 @@ require 'best_buy/models/product'
 require 'best_buy/models/shipping_level_of_service'
 require 'best_buy/models/store'
 
-require 'generators/best_buy/config/config_generator'
+require 'generators/best_buy/config/config_generator' if defined? Rails::Generators

--- a/lib/best_buy.rb
+++ b/lib/best_buy.rb
@@ -6,6 +6,8 @@ require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/string'
 require 'faraday'
 
+require 'best_buy/exceptions/api_key_not_found'
+
 require 'best_buy/helpers/api_helper'
 require 'best_buy/helpers/conditions/category_condition'
 require 'best_buy/helpers/conditions/max_price_condition'
@@ -14,6 +16,7 @@ require 'best_buy/helpers/conditions/new_condition'
 require 'best_buy/helpers/conditions/pre_owned_condition'
 require 'best_buy/helpers/conditions/refurbished_condition'
 
+require 'best_buy/config'
 require 'best_buy/base_api'
 require 'best_buy/categories'
 require 'best_buy/products'

--- a/lib/best_buy/base_api.rb
+++ b/lib/best_buy/base_api.rb
@@ -11,7 +11,9 @@ module BestBuy
 
     attr_reader :api_key
 
-    def initialize(api_key)
+    def initialize(api_key = BestBuy.config.api_key)
+      raise Exceptions::ApiKeyNotFound unless api_key
+
       @api_key = api_key
     end
 

--- a/lib/best_buy/config.rb
+++ b/lib/best_buy/config.rb
@@ -6,6 +6,10 @@ module BestBuy
       yield config
     end
 
+    def reset_configuration
+      @config = Config.new
+    end
+
     def config
       @config ||= Config.new
     end

--- a/lib/best_buy/exceptions/api_key_not_found.rb
+++ b/lib/best_buy/exceptions/api_key_not_found.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module BestBuy
+  module Exceptions
+    class ApiKeyNotFound < StandardError
+      def message
+        'No API key configured. Either configure it in config/initializers/best_buy.rb '\
+          'or pass it as a parameter when creating the API instance.'
+      end
+    end
+  end
+end

--- a/spec/base_api_spec.rb
+++ b/spec/base_api_spec.rb
@@ -28,9 +28,9 @@ RSpec.describe BestBuy::BaseAPI do
     end
   end
 
-  describe '#get_all' do
-    let(:api_key) { '111111' }
+  let(:api_key) { '111111' }
 
+  describe '#get_all' do
     let(:url) { BestBuy::BaseAPI::BASE_URL + TestCollections::TEST_COLLECTIONS_API }
     let(:search_query) { '' }
     let(:request_params) do
@@ -151,6 +151,42 @@ RSpec.describe BestBuy::BaseAPI do
           test_collections_api.get_all(pagination: { page: page, page_size: page_size })
 
           expect(stubbed_request).to have_been_requested
+        end
+      end
+    end
+  end
+
+  describe 'initialization' do
+    context 'when an api_key is passed as parameter' do
+      it 'the api_key is stored as an instance variable' do
+        test_collections_api = TestCollections.new(api_key)
+
+        expect(test_collections_api.api_key).to eq api_key
+      end
+    end
+
+    context 'when no api_key is passed as parameter' do
+      context 'and it has been added to the configuration' do
+        before do
+          BestBuy.configure do |config|
+            config.api_key = api_key
+          end
+        end
+
+        after do
+          BestBuy.reset_configuration
+        end
+
+        it 'the configured api_key is stored as an instance variable' do
+          test_collections_api = TestCollections.new
+
+          expect(test_collections_api.api_key).to eq api_key
+        end
+      end
+
+      context 'and it has not been added to the configuration' do
+        it 'an error is raised' do
+          expect { TestCollections.new }.to raise_error BestBuy::Exceptions::ApiKeyNotFound
         end
       end
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe BestBuy do
+  let(:api_key) { '111111' }
+
+  def configure_api_key
+    BestBuy.configure do |config|
+      config.api_key = api_key
+    end
+  end
+
+  describe '.configure' do
+    it 'adds the configuration to the module' do
+      configure_api_key
+
+      expect(BestBuy.config.api_key).to eq api_key
+    end
+  end
+
+  describe '.reset_configuration' do
+    before do
+      configure_api_key
+    end
+
+    it 'resets all the configuration of the module' do
+      BestBuy.reset_configuration
+
+      expect(BestBuy.config.api_key).not_to be_present
+    end
+  end
+end


### PR DESCRIPTION
Make APIs able to use the API key added in the `config/initializers/best_buy.rb` file

Closes #22 